### PR TITLE
Issue 38 load function arg improvements

### DIFF
--- a/ramp-for-gutenberg.php
+++ b/ramp-for-gutenberg.php
@@ -33,13 +33,20 @@ include __DIR__ . '/inc/admin/class-ramp-for-gutenberg-post-type-settings-ui.php
 * `ramp_for_gutenberg_load_gutenberg` must be called in the theme before `admin_init`, normally from functions.php or the like
 *
 */
-function ramp_for_gutenberg_load_gutenberg( $criteria = false ) {
+function ramp_for_gutenberg_load_gutenberg( $criteria = true ) {
 	// prevent the front-end from interacting with this plugin at all
 	if ( !is_admin() ) {
 		return;
 	}
 	$RFG = Ramp_For_Gutenberg::get_instance();
-	$criteria = ( !$criteria ) ? [ 'load' => 1 ] : $criteria;
+
+	// Accept bool as $criteria or as $criteria['load']
+	if ( false === $criteria || ( is_array( $criteria ) && isset( $criteria['load'] ) && false === $criteria['load'] ) ) {
+		$criteria = [ 'load' => 0 ];
+	} elseif ( true === $criteria || ( is_array( $criteria ) && isset( $criteria['load'] ) && true === $criteria['load'] ) ) {
+		$criteria = [ 'load' => 1 ];
+	}
+
 	$stored_criteria = $RFG->get_criteria();
 	if ( $criteria !== $stored_criteria ) {
 		// the criteria specified in code have changed -- update them

--- a/ramp-for-gutenberg.php
+++ b/ramp-for-gutenberg.php
@@ -25,35 +25,47 @@ include __DIR__ . '/inc/class-ramp-for-gutenberg.php';
 include __DIR__ . '/inc/admin/class-ramp-for-gutenberg-post-type-settings-ui.php';
 
 /**
-*
-* This function allows themes to specify Gutenberg loading critera.
-* In and of itself it doesn't cause any change to Gutenberg's loading behavior.
-* However, it governs the option which stores the criteria under which Gutenberg will load 
-*
-* `ramp_for_gutenberg_load_gutenberg` must be called in the theme before `admin_init`, normally from functions.php or the like
-*
-*/
+ *
+ * This function allows themes to specify Gutenberg loading critera.
+ * In and of itself it doesn't cause any change to Gutenberg's loading behavior.
+ * However, it governs the option which stores the criteria under which Gutenberg will load.
+ *
+ * `ramp_for_gutenberg_load_gutenberg` must be called in the theme before `admin_init`, normally from functions.php or the like.
+ *
+ * @param bool|Array $criteria The criteria used to determine whether Gutenberg should be loaded
+ */
 function ramp_for_gutenberg_load_gutenberg( $criteria = true ) {
+
 	// prevent the front-end from interacting with this plugin at all
-	if ( !is_admin() ) {
+	if ( ! is_admin() ) {
 		return;
 	}
+
 	$RFG = Ramp_For_Gutenberg::get_instance();
 
 	// Accept bool as $criteria or as $criteria['load']
 	if ( false === $criteria || ( is_array( $criteria ) && isset( $criteria['load'] ) && false === $criteria['load'] ) ) {
+
 		$criteria = [ 'load' => 0 ];
+
 	} elseif ( true === $criteria || ( is_array( $criteria ) && isset( $criteria['load'] ) && true === $criteria['load'] ) ) {
+
 		$criteria = [ 'load' => 1 ];
+
 	}
 
 	$stored_criteria = $RFG->get_criteria();
+
 	if ( $criteria !== $stored_criteria ) {
+
 		// the criteria specified in code have changed -- update them
 		$criteria = $RFG->set_criteria( $criteria );
+
 	}
-	// indicate that we've loaded the plugin. 
+
+	// indicate that we've loaded the plugin.
 	$RFG->active = true;
+
 }
 
 /** grab the plugin **/


### PR DESCRIPTION
#38 Allow booleans to be passed in as criteria.

Modifies `ramp_for_gutenberg_load_gutenberg()` to accept a boolean to be passed in as `$criteria` either by itself or in an associative array as `load`.

Also changes the default `$criteria` value to `true`. This doesn't change any functionality as calling the function with no args previously was the same as passing `[ 'load' => 1 ]`, but was needed to preserve that original functionality with the added checks.