### PR TITLE
Update code examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,39 @@ Loading behavior is controlled by the `gutenberg_ramp_load_gutenberg()` function
 
 ### Code Examples
 
-```
+Load Gutenberg for all posts:
+```php
 if ( function_exists( 'gutenberg_ramp_load_gutenberg' ) ) {
 	gutenberg_ramp_load_gutenberg();
 }
 ```
 
-Load Gutenberg for all posts.
 
-`gutenberg_ramp_load_gutenberg( [ 'load' => 0 ] );`
+Never load Gutenberg:
+```php
+gutenberg_ramp_load_gutenberg( false );
 
-Never load Gutenberg.
+// Alternatively, you can use the `load` key to always disable Gutenberg:
+gutenberg_ramp_load_gutenberg( [ 'load' => 0 ] );
+```
 
-`gutenberg_ramp_load_gutenberg( [ 'post_ids' => [ 12, 13, 122 ] ] );`
+Load Gutenberg only for posts with ids 12, 13 and 122:
+```php
+gutenberg_ramp_load_gutenberg( [ 'post_ids' => [ 12, 13, 122 ] ] );
+```
 
-Load Gutenberg only for posts with ids 12, 13 and 122.
 
-`gutenberg_ramp_load_gutenberg( [ 'post_types' => [ 'test', 'scratch' ], 'post_ids' => [ 12 ] ] );`
+Load Gutenberg for `post_id: 12` and all posts of type `test` and `scratch`:
 
-Load Gutenberg for post_id 12 and all posts of type `test` and `scratch`
+```php
+gutenberg_ramp_load_gutenberg(
+	[
+		'post_types' => [ 'test', 'scratch' ],
+		'post_ids'   => [ 12 ],
+	]
+);
+```
+
 
 ### UI
 


### PR DESCRIPTION
I reorganized the code examples in readme - I think that the format `Label: Code` is going to be easier to understand.

Also added syntax highlighting and indented the more complex example.