### PR TITLE
Prepare for .org release

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ The parameter supplied in the function is persisted in a site option. Therefore,
 
 **Can I contribute to this plugin?**
 
-Absolutely! Please create issues and pull requests on [GitHub here.](https://github.com/Automattic/ramp-for-gutenberg)
+Absolutely! Please create issues and pull requests on [GitHub here.](https://github.com/Automattic/gutenberg-ramp)

--- a/gutenberg-ramp.php
+++ b/gutenberg-ramp.php
@@ -4,7 +4,7 @@
  *
  * Plugin Name: Gutenberg Ramp
  * Description: Allows theme authors to control the circumstances under which the Gutenberg editor loads. Options include "load" (1 loads all the time, 0 loads never) "post_ids" (load for particular posts) "post_types" (load for particular posts types.)
- * Version:     0.1
+ * Version:     1.0.0
  * Author:      Automattic, Inc.
  * License:     GPL-2.0+
  * License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php
+++ b/inc/admin/class-gutenberg-ramp-post-type-settings-ui.php
@@ -128,7 +128,7 @@ class Gutenberg_Ramp_Post_Type_Settings_UI {
 							</label>
 							<?php if ( $is_helper_enabled_post_type ): ?>
 								<small style="margin-left: 1rem;">
-									<a href="https://github.com/Automattic/ramp-for-gutenberg#faqs"><?php esc_html_e( 'Why is this disabled?', 'gutenberg-ramp' ); ?></a>
+									<a href="https://github.com/Automattic/gutenberg-ramp#faqs"><?php esc_html_e( 'Why is this disabled?', 'gutenberg-ramp' ); ?></a>
 								</small>
 							<?php endif; ?>
 							<br>
@@ -146,7 +146,7 @@ class Gutenberg_Ramp_Post_Type_Settings_UI {
 					esc_html__( 'For more granular control you can use the %s function.', 'gutenberg-ramp' ),
 					'<code>gutenberg_ramp_load_gutenberg()</code>'
 				); ?>
-				<a href="https://github.com/Automattic/ramp-for-gutenberg#faqs" target="_blank"><?php esc_html_e( 'Learn more', 'gutenberg-ramp' ); ?></a>
+				<a href="https://github.com/Automattic/gutenberg-ramp#faqs" target="_blank"><?php esc_html_e( 'Learn more', 'gutenberg-ramp' ); ?></a>
 			</p>
 		</div>
 		<?php

--- a/readme.txt
+++ b/readme.txt
@@ -28,25 +28,37 @@ Loading behaviour is controlled by the `gutenberg_ramp_load_gutenberg()` functio
 
 == Code Examples ==
 
+Load Gutenberg for all posts:
 ```
 if ( function_exists( 'gutenberg_ramp_load_gutenberg' ) ) {
 	gutenberg_ramp_load_gutenberg();
 }
 ```
 
-Load Gutenberg for all posts.
 
-`gutenberg_ramp_load_gutenberg( [ 'load' => 0 ] );`
+Never load Gutenberg:
+```
+gutenberg_ramp_load_gutenberg( false );
 
-Do not load Gutenberg for any posts.
+// Alternatively, you can use the `load` key to always disable Gutenberg:
+gutenberg_ramp_load_gutenberg( [ 'load' => 0 ] );
+```
 
-`gutenberg_ramp_load_gutenberg( [ 'post_ids' => [ 12, 13, 122 ] ] );`
+Load Gutenberg only for posts with ids 12, 13 and 122:
+```
+gutenberg_ramp_load_gutenberg( [ 'post_ids' => [ 12, 13, 122 ] ] );
+```
 
-Load Gutenberg for posts with ids 12, 13 and 122.
 
-`gutenberg_ramp_load_gutenberg( [ 'post_types' => [ 'test', 'scratch' ], 'post_ids' => [ 12 ] ] );`
-
-Load Gutenberg for post_id 12 and all posts of type test and scratch
+Load Gutenberg for `post_id: 12` and all posts of type `test` and `scratch`:
+```php
+gutenberg_ramp_load_gutenberg(
+	[
+		'post_types' => [ 'test', 'scratch' ],
+		'post_ids'   => [ 12 ],
+	]
+);
+```
 
 == Advanced ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Gutenberg Ramp ===
 Contributors: automattic, mattoperry, justnorris, enigmaweb
 Tags: gutenberg, ramp, classic editor, legacy editor, gutenberg ramp
-Requires at least: 2.7
-Tested up to: 4.9.5
+Requires at least: 4.9.6
+Tested up to: 4.9.6
 Requires PHP: 5.5
 Stable tag: trunk
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -56,7 +56,7 @@ If making more dynamic changes, note that the parameter supplied is persisted in
 
 == Contributions ==
 
-Contributions are welcome via our [GitHub repo.](https://github.com/Automattic/ramp-for-gutenberg)
+Contributions are welcome via our [GitHub repo.](https://github.com/Automattic/gutenberg-ramp)
 
 == Installation ==
 
@@ -72,7 +72,7 @@ If you're seeing something greyed out, it means the `gutenberg_ramp_load_gutenbe
 
 = Some post types are not showing up on the settings screen =
 
-Post types that are not compatible with Gutenberg will not show up. If you think you have found a false negative (posts in that post type DO work with Gutenberg, when Ramp plugin is deactivated) please report it as an issue on [GitHub here.](https://github.com/Automattic/ramp-for-gutenberg)
+Post types that are not compatible with Gutenberg will not show up. If you think you have found a false negative (posts in that post type DO work with Gutenberg, when Ramp plugin is deactivated) please report it as an issue on [GitHub here.](https://github.com/Automattic/gutenberg-ramp)
 
 = The changes I'm making in functions.php are not showing up =
 
@@ -80,7 +80,7 @@ The parameter supplied in the function is persisted in a site option. Therefore,
 
 = Can I contribute to this plugin? =
 
-Absolutely! Please create issues and pull requests on [GitHub here.](https://github.com/Automattic/ramp-for-gutenberg)
+Absolutely! Please create issues and pull requests on [GitHub here.](https://github.com/Automattic/gutenberg-ramp)
 
 == Screenshots ==
 


### PR DESCRIPTION
Updated readme's and inline docs, updated to use the "future" GitHub URL (gutenberg-ramp as opposed to ramp-for-gutenberg) and synced code examples - everything jumbled in a single PR :)